### PR TITLE
Pull for Sugar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-lunr-mutable.js
 node_modules/
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ lunr-mutable.js: lib/mutable_builder.js lib/mutable_index.js lib/lunr_mutable.js
 
 test: lunr-mutable.js
 	${MOCHA} test/*.js -u tdd -R dot
+
+clean:
+	rm lunr-mutable.js

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MOCHA=mocha
 
 all: lunr-mutable.js test
 
-lunr-mutable.js: lib/mutable_builder.js lib/mutable_index.js
+lunr-mutable.js: lib/mutable_builder.js lib/mutable_index.js lib/lunr_mutable.js
 	cat preamble $^ postamble > $@
 
 test: lunr-mutable.js

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A simple search index can be created with the familiar `lunr` syntax; just subst
 
 ```js
 
-var lunrMutable = require('lunr-mutable');
+var lunrMutable = require('lunr-mutable-indexes');
 
 var index = lunrMutable(function () {
   this.field('title')
@@ -52,7 +52,7 @@ index.update({
 });
 ```
 
-Index serialization also works, with the Index namespace accessible through the lunrMutable object.
+Index serialization also works, with the Index namespace accessible through the `lunr-mutable-indexes` object.
 
 ```js
 // Serialize an index:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ A simple search index can be created with the familiar `lunr` syntax; just subst
 
 var lunrMutable = require('lunr-mutable');
 
-var index = builder.build();
-
 var index = lunrMutable(function () {
   this.field('title')
   this.field('body')

--- a/README.md
+++ b/README.md
@@ -7,60 +7,69 @@ their indexes with new data.  That's what this library is for.
 
 # Example
 
+A simple search index can be created with the familiar `lunr` syntax; just substitute `lunr-mutable` for `lunr`.
+
 ```js
 
-var lunr = require('lunr');
-var { MutableBuilder, MutableIndex } = require('lunr-mutable');
+var lunrMutable = require('lunr-mutable');
 
-var builder = new MutableBuilder();
+var index = builder.build();
 
-// Add default pipeline and searchPipeline components - sorry,
-// no sugary builder function yet!
-builder.pipeline.add(
-  lunr.trimmer,
-  lunr.stopWordFilter,
-  expandQuery,
-  lunr.stemmer
-);
+var index = lunrMutable(function () {
+  this.field('title')
+  this.field('body')
 
-builder.searchPipeline.add(
-  lunr.stemmer
-);
-
-// Define the fields of documents
-builder.field('title');
-builder.field('body');
-
-builder.add({
+  this.add({
     "title": "Twelfth-Night",
     "body": "If music be the food of love, play on: Give me excess of it…",
     "author": "William Shakespeare",
     "id": "1"
-});
+  })
+})
+```
 
-// Works just like lunr.js
-var index = builder.build();
+Now, with a mutable index, we can add...
 
-// But now you can add...
+```js
 index.add({
     "title": "Merchant of Venice",
     "body": "You speak an infinite deal of nothing.",
     "author": "William Shakespeare",
     "id": "2"
 });
+```
 
-// remove...
+Remove...
+
+```js
 index.remove({ id: "1" });
+```
 
-// or update existing documents.
+Or update existing documents.
+
+```js
 index.update({
     "body": "With mirth and laughter let old wrinkles come.",
     "id": "2"
 });
+```
 
-// You can also serialize an index:
+Index serialization also works, with the Index namespace accessible through the lunrMutable object.
+
+```js
+// Serialize an index:
 var serialized = JSON.stringify(index);
 
 // ...and deserialize it later:
-var sameIndex = MutableIndex.load(JSON.parse(serialized));
+var sameIndex = lunrMutable.Index.load(JSON.parse(serialized));
 ```
+
+# Caveats
+
+The main tradeoffs with `lunr-mutable-index` were originally discussed in [this PR](https://github.com/olivernn/lunr.js/pull/315) in `lunr`.
+* Mutable indexes work by having a handle to their original builder - this inflates the index size a bit.
+* Changing a builder's tokenizer won't persist across serialization boundaries.
+* Gaps in builder.termIndex may build up when documents are deleted.
+* The index is completely rebuilt when a document is added/updated/removed
+
+Work is ongoing to make improvements with these potential drawbacks, but please feel free to contribute fixes!

--- a/lib/lunr_mutable.js
+++ b/lib/lunr_mutable.js
@@ -1,0 +1,60 @@
+/**
+ * A convenience function for configuring and constructing
+ * a new mutable lunr Index.
+ *
+ * A lunr.MutableBuilder instance is created and the pipeline setup
+ * with a trimmer, stop word filter and stemmer.
+ *
+ * This mutable builder object is yielded to the configuration function
+ * that is passed as a parameter, allowing the list of fields
+ * and other builder parameters to be customised.
+ *
+ * All documents _must_ be added within the passed config function, but
+ * you can always update the index later. ;)
+ *
+ * @example
+ * var idx = lunrMutable(function () {
+ *   this.field('title')
+ *   this.field('body')
+ *   this.ref('id')
+ *
+ *   documents.forEach(function (doc) {
+ *     this.add(doc)
+ *   }, this)
+ * })
+ *
+ * index.add({
+ *     "title": "new title",
+ *     "body": "new body",
+ *     "id": "2"
+ * })
+ *
+ * index.remove({ id: "1" });
+ *
+ * index.update({
+ *   "body": "change",
+ *   "id": "2"
+ * })
+ */
+
+var lunrMutable = function (config) {
+  var builder = new MutableBuilder();
+
+  builder.pipeline.add(
+    lunr.trimmer,
+    lunr.stopWordFilter,
+    lunr.stemmer
+  )
+
+  builder.searchPipeline.add(
+    lunr.stemmer
+  )
+
+  config.call(builder, builder)
+  return builder.build()
+}
+
+lunrMutable.version = "@VERSION"
+
+lunrMutable.Builder = MutableBuilder
+lunrMutable.Index = MutableIndex

--- a/lunr-mutable.js
+++ b/lunr-mutable.js
@@ -1,0 +1,306 @@
+(function() {
+
+var lunr = require('lunr');
+/*
+ * Copyright 2018 Rob Hoelz <rob AT hoelz.ro>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+var MutableBuilder = function () {
+  lunr.Builder.call(this)
+}
+
+MutableBuilder.prototype = new lunr.Builder()
+
+MutableBuilder.prototype.build = function build () {
+  this.calculateAverageFieldLengths()
+  this.createFieldVectors()
+  this.createTokenSet()
+
+  return new MutableIndex({
+    invertedIndex: this.invertedIndex,
+    fieldVectors: this.fieldVectors,
+    tokenSet: this.tokenSet,
+    fields: this._fields,
+    pipeline: this.searchPipeline,
+    builder: this
+  })
+}
+
+MutableBuilder.prototype.remove = function remove (doc) {
+  var docRef = doc[this._ref]
+
+  this.documentCount -= 1
+
+  for (var i = 0; i < this._fields.length; i++) {
+    var fieldName = this._fields[i],
+        fieldRef = new lunr.FieldRef (docRef, fieldName)
+
+    delete this.fieldTermFrequencies[fieldRef]
+    delete this.fieldLengths[fieldRef]
+  }
+
+  // XXX what if a term disappears from the index?
+  for (var term in this.invertedIndex) {
+    for (var fieldName in this.invertedIndex[term]) { // XXX what about "_index"?
+      delete this.invertedIndex[term][fieldName][docRef]
+    }
+  }
+}
+
+MutableBuilder.prototype.toJSON = function toJSON () {
+  var fieldRefs = []
+  var fieldTermFrequencies = []
+  var fieldLengths = []
+
+  for (var fieldRef in this.fieldTermFrequencies) {
+    if (this.fieldTermFrequencies.hasOwnProperty(fieldRef)) {
+      fieldRefs.push(fieldRef)
+      fieldTermFrequencies.push(this.fieldTermFrequencies[fieldRef])
+      fieldLengths.push(this.fieldLengths[fieldRef])
+    }
+  }
+
+  // XXX omit tokenizer for now
+  // some properties (_fields, invertedIndex, searchPipeline) are omitted
+  // from here because they're on the index, and serializing them twice
+  // would be redundant
+  return {
+    _ref: this._ref,
+    fieldRefs: fieldRefs,
+    fieldTermFrequencies: fieldTermFrequencies,
+    fieldLengths: fieldLengths,
+    pipeline: this.pipeline.toJSON(),
+    documentCount: this.documentCount,
+    _b: this._b, // XXX special (due to precision)?
+    _k1: this._k1, // XXX special (due to precision)?
+    termIndex: this.termIndex,
+    metadataWhitelist: this.metadataWhitelist
+  }
+}
+
+MutableBuilder.load = function load (serializedBuilder) {
+  var builder = new MutableBuilder()
+
+  for (var k in serializedBuilder) {
+    if (serializedBuilder.hasOwnProperty(k)) {
+      builder[k] = serializedBuilder[k]
+    }
+  }
+
+  var fieldRefs = builder.fieldRefs
+  var fieldTermFrequencies = builder.fieldTermFrequencies
+  var fieldLengths = builder.fieldLengths
+  delete builder.fieldRefs
+
+  builder.fieldTermFrequencies = {}
+  builder.fieldLengths = {}
+
+  for (var i = 0; i < fieldRefs.length; i++) {
+    var fieldRef = fieldRefs[i]
+    builder.fieldTermFrequencies[fieldRef] = fieldTermFrequencies[i]
+    builder.fieldLengths[fieldRef] = fieldLengths[i]
+  }
+
+  // builder.tokenizer is initialized to the default by the MutableBuilder
+  // constructor
+  builder.pipeline = lunr.Pipeline.load(builder.pipeline)
+
+  return builder
+}
+/*
+ * Copyright 2018 Rob Hoelz <rob AT hoelz.ro>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+var MutableIndex = function (attrs) {
+  lunr.Index.call(this, attrs)
+  this.builder = attrs.builder
+  this._dirty = false
+}
+
+MutableIndex.prototype = new lunr.Index({})
+
+MutableIndex.prototype.add = function add (doc) {
+  this.builder.add(doc)
+  this._dirty = true
+}
+
+MutableIndex.prototype.update = function update (doc) {
+  this.remove(doc)
+  this.add(doc)
+}
+
+MutableIndex.prototype.remove = function remove (doc) {
+  this.builder.remove(doc)
+  this._dirty = true
+}
+
+// XXX rebuilds the entire index =(
+// XXX refreshing this from newIndex is kinda wonky =(
+MutableIndex.prototype.checkDirty = function checkDirty () {
+  if (this._dirty) {
+    this._dirty = false
+    var newIndex = this.builder.build()
+    for (var k in newIndex) {
+      if (newIndex.hasOwnProperty(k)) {
+        this[k] = newIndex[k]
+      }
+    }
+  }
+}
+
+MutableIndex.prototype.toJSON = function toJSON () {
+  this.checkDirty()
+
+  var json = lunr.Index.prototype.toJSON.call(this)
+  json.builder = this.builder.toJSON()
+  return json
+}
+
+MutableIndex.load = function load (serializedIndex) {
+  var index = lunr.Index.load(serializedIndex)
+  var mutableIndex = new MutableIndex({})
+
+  for (var k in index) {
+    if (index.hasOwnProperty(k)) {
+      mutableIndex[k] = index[k]
+    }
+  }
+
+  mutableIndex.builder = MutableBuilder.load(serializedIndex.builder)
+  mutableIndex.builder.invertedIndex = mutableIndex.invertedIndex
+  mutableIndex.builder._fields = mutableIndex.fields
+  mutableIndex.builder.searchPipeline = mutableIndex.pipeline
+  mutableIndex.dirty = false
+
+  return mutableIndex
+}
+
+MutableIndex.prototype.query = function query (fn) {
+  this.checkDirty()
+
+  return lunr.Index.prototype.query.call(this, fn)
+}
+/**
+ * A convenience function for configuring and constructing
+ * a new mutable lunr Index.
+ *
+ * A lunr.MutableBuilder instance is created and the pipeline setup
+ * with a trimmer, stop word filter and stemmer.
+ *
+ * This mutable builder object is yielded to the configuration function
+ * that is passed as a parameter, allowing the list of fields
+ * and other builder parameters to be customised.
+ *
+ * All documents _must_ be added within the passed config function, but
+ * you can always update the index later. ;)
+ *
+ * @example
+ * var idx = lunrMutable(function () {
+ *   this.field('title')
+ *   this.field('body')
+ *   this.ref('id')
+ *
+ *   documents.forEach(function (doc) {
+ *     this.add(doc)
+ *   }, this)
+ * })
+ *
+ * index.add({
+ *     "title": "new title",
+ *     "body": "new body",
+ *     "id": "2"
+ * })
+ *
+ * index.remove({ id: "1" });
+ *
+ * index.update({
+ *   "body": "change",
+ *   "id": "2"
+ * })
+ */
+
+var lunrMutable = function (config) {
+  var builder = new MutableBuilder();
+
+  builder.pipeline.add(
+    lunr.trimmer,
+    lunr.stopWordFilter,
+    lunr.stemmer
+  )
+
+  builder.searchPipeline.add(
+    lunr.stemmer
+  )
+
+  config.call(builder, builder)
+  return builder.build()
+}
+
+lunrMutable.version = "@VERSION"
+
+lunrMutable.Builder = MutableBuilder
+lunrMutable.Index = MutableIndex
+  /**
+   * export the module via AMD, CommonJS or as a browser global
+   * Export code from https://github.com/umdjs/umd/blob/master/returnExports.js
+   */
+  ;(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+      // AMD. Register as an anonymous module.
+      define(factory)
+    } else if (typeof exports === 'object') {
+      /**
+       * Node. Does not work with strict CommonJS, but
+       * only CommonJS-like enviroments that support module.exports,
+       * like Node.
+       */
+      module.exports = factory()
+    } else {
+      // Browser globals (root is window)
+      root.lunr = factory()
+    }
+  }(this, function () {
+    /**
+     * Just return a value to define the module export.
+     * This example returns an object, but the module
+     * can return a function as the exported value.
+     */
+    return lunrMutable
+  }))
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,338 @@
+{
+  "name": "lunr-mutable-indexes",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lunr": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.1.5.tgz",
+      "integrity": "sha512-5Q8Q5Lu88qkQ7vwKyQXistAtgPHI+Ynmu796Od6/hTuFp3JLcQqftsRDAcu9eorzerl6xPKuH7KMhaxx0neYVQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/postamble
+++ b/postamble
@@ -24,8 +24,6 @@
      * can return a function as the exported value.
      */
     return {
-        MutableBuilder: MutableBuilder,
-        MutableIndex: MutableIndex
-    }
+        lunrMutable
   }))
 })();

--- a/postamble
+++ b/postamble
@@ -23,7 +23,6 @@
      * This example returns an object, but the module
      * can return a function as the exported value.
      */
-    return {
-        lunrMutable
+    return lunrMutable
   }))
 })();

--- a/test/mutable_serialization_test.js
+++ b/test/mutable_serialization_test.js
@@ -1,6 +1,6 @@
 var lunr = require('lunr');
 var assert = require('chai').assert;
-var { MutableBuilder, MutableIndex } = require('../lunr-mutable.js');
+var lunrMutable = require('../lunr-mutable.js');
 
 suite('mutable serialization', function () {
   setup(function () {
@@ -21,7 +21,7 @@ suite('mutable serialization', function () {
       wordCount: 16
     }]
 
-    var builder = new MutableBuilder
+    var builder = new lunrMutable.Builder
 
     builder.pipeline.add(
       lunr.trimmer,
@@ -55,7 +55,7 @@ suite('mutable serialization', function () {
     });
 
     this.serializedIdx = JSON.stringify(this.idx)
-    this.loadedIdx = MutableIndex.load(JSON.parse(this.serializedIdx))
+    this.loadedIdx = lunrMutable.Index.load(JSON.parse(this.serializedIdx))
   })
 
   test('loadedAddWorked', function () {

--- a/test/mutable_sugar_test.js
+++ b/test/mutable_sugar_test.js
@@ -1,4 +1,3 @@
-var lunr = require('lunr');
 var assert = require('chai').assert;
 var lunrMutable = require('../lunr-mutable.js');
 

--- a/test/mutable_sugar_test.js
+++ b/test/mutable_sugar_test.js
@@ -21,31 +21,15 @@ suite('mutable indexes', function () {
       wordCount: 16
     }]
 
-    var builder = new lunrMutable.Builder
+    this.idx = lunrMutable(function () {
+       this.field('title')
+       this.field('body')
+       this.ref('id')
 
-    builder.pipeline.add(
-      lunr.trimmer,
-      lunr.stopWordFilter,
-      lunr.stemmer
-    )
-
-    builder.searchPipeline.add(
-      lunr.stemmer
-    )
-
-    var config = function () {
-      this.ref('id')
-      this.field('title')
-      this.field('body')
-
-      documents.forEach(function (document) {
-        this.add(document)
-      }, this)
-    }
-
-    config.call(builder, builder)
-
-    this.idx = builder.build()
+       documents.forEach(function (document) {
+         this.add(document)
+       }, this)
+    })
 
     this.idx.add({
       id: 'd',


### PR DESCRIPTION
Went ahead and got this project all set up so that you can just pull from `npm` and go.  Things were rearranged quite a bit by stashing the MutableBuilder and MutableIndex behind a 'lunrMutable' object to implement the 'syntactic sugar'. If there is a cleaner or better approach, I would be OK with it.

To get things working correctly from a `npm` install, the lunr-mutable.js had to be included in the repo, so I removed it from `.gitignore`. To compensate, I added a `make clean`  target to the `Makefile`. The Make stuff seems clunky, but this is the first published `npm` module that I have contributed to, so maybe that's just how it's done?

Also, the README is updated with the latest instructions and a reference back to the `lunr` pull request. It would be nice if @olivernn decides to bring the mutable changes back into `lunr`, but having this module to update against will be suitable in the interim.

The next target IMHO is definitely to go after the index rebuild problem, but this will work for now. Thanks again @hoelzro for bringing this to life!